### PR TITLE
修复多个codepoint组成的emoji的显示问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,9 +78,21 @@ function renderEmoji(emojis, name) {
 
   //styles.push(`background-image: url(${emojis[name].src})`);
 
-  const codepoints = emojis[name].codepoints
-    ? emojis[name].codepoints.map(c => `&#x${c};`).join('')
-    : ' ';
+  var codepoints;
+
+  if (emojis[name].codepoints && emojis[name].codepoints.length>1){
+    // 对于多个codepoint组成的emoji添加连接符或修饰符
+    var firstCode = emojis[name].codepoints[0];
+    if((firstCode>='0030' && firstCode<='0039') || ['002a','0023'].includes(firstCode)){
+      //数字或符号（#，*）
+      codepoints = emojis[name].codepoints.map(c => `&#x${c};`).join('&#xfe0f;');
+    }else{
+      codepoints = emojis[name].codepoints.map(c => `&#x${c};`).join('&#xfe0f;&#x200d;');
+    }
+  }else
+    codepoints = emojis[name].codepoints
+      ? emojis[name].codepoints.map(c => `&#x${c};`).join('')
+      : ' ';
 
   return `<span class="${options.className}" alias="${name}" style="${styles.join('; ')}" fallback-src="${emojis[name].src}">${codepoints}</span>`;
 }

--- a/index.js
+++ b/index.js
@@ -80,19 +80,19 @@ function renderEmoji(emojis, name) {
 
   var codepoints;
 
-  if (emojis[name].codepoints && emojis[name].codepoints.length>1){
-    // 对于多个codepoint组成的emoji添加连接符或修饰符
+  if (emojis[name].codepoints && emojis[name].codepoints.length > 1) {
+    // 对于多个 codepoint 组成的 emoji 添加连接符或修饰符
     var firstCode = emojis[name].codepoints[0];
-    if((firstCode>='0030' && firstCode<='0039') || ['002a','0023'].includes(firstCode)){
-      //数字或符号（#，*）
+    if ((firstCode >= '0030' && firstCode <= '0039') || ['002a', '0023'].includes(firstCode)) {
+      // 数字或符号（#，*）
       codepoints = emojis[name].codepoints.map(c => `&#x${c};`).join('&#xfe0f;');
-    }else{
+    } else {
       codepoints = emojis[name].codepoints.map(c => `&#x${c};`).join('&#xfe0f;&#x200d;');
     }
-  }else
+  } else {
     codepoints = emojis[name].codepoints
       ? emojis[name].codepoints.map(c => `&#x${c};`).join('')
       : ' ';
-
+  }
   return `<span class="${options.className}" alias="${name}" style="${styles.join('; ')}" fallback-src="${emojis[name].src}">${codepoints}</span>`;
 }


### PR DESCRIPTION
原来从GitHub的api中获取的emoji的codepoints会存在遗漏连接符的情况，导致如果由多个codepoint组成的emoji显示不正常，如数字:eight: 和非数字的:family_woman_woman_girl_girl:。

现在做了一个特殊情况判断，对于多个codepoint的emoji添加\ufe0f和\u200d来链接，经测试显示正常。